### PR TITLE
Rewrite stress testing tool and fix bug handling trailing newlines

### DIFF
--- a/server/proto/parse.go
+++ b/server/proto/parse.go
@@ -206,12 +206,13 @@ func parseSet(line string, parts []string, payload io.Reader) (*SetOp, error) {
 		return nil, core.ClientError("length of %d greater than max item size of %d", length, maxPayloadSizeBytes)
 	}
 
-	bytes := make([]byte, length)
+	bytes := make([]byte, length+2) // payload and trailing \r\n
 	n, err := io.ReadFull(payload, bytes)
 	if err != nil {
-		return nil, core.ClientError("unable to read %d payload bytes, only read %d: %s", length, n, err)
+		return nil, core.ClientError("unable to read %d+2 payload bytes, only read %d: %s", length, n, err)
 	}
 
+	bytes = bytes[:length] // truncate trailing \r\n
 	noreply := len(parts) > 5 && "noreply" == strings.ToLower(parts[5])
 
 	return &SetOp{

--- a/tools/reads-and-writes.go
+++ b/tools/reads-and-writes.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
+	"io/fs"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -13,197 +15,48 @@ import (
 )
 
 const numBatches = 10
-const batchSize = 1000
-const numWrites = 45
-const payload = `
-{
-    "@context": [
-        "https://geojson.org/geojson-ld/geojson-context.jsonld",
-        {
-            "@version": "1.1",
-            "wx": "https://api.weather.gov/ontology#",
-            "s": "https://schema.org/",
-            "geo": "http://www.opengis.net/ont/geosparql#",
-            "unit": "http://codes.wmo.int/common/unit/",
-            "@vocab": "https://api.weather.gov/ontology#",
-            "geometry": {
-                "@id": "s:GeoCoordinates",
-                "@type": "geo:wktLiteral"
-            },
-            "city": "s:addressLocality",
-            "state": "s:addressRegion",
-            "distance": {
-                "@id": "s:Distance",
-                "@type": "s:QuantitativeValue"
-            },
-            "bearing": {
-                "@type": "s:QuantitativeValue"
-            },
-            "value": {
-                "@id": "s:value"
-            },
-            "unitCode": {
-                "@id": "s:unitCode",
-                "@type": "@id"
-            },
-            "forecastOffice": {
-                "@type": "@id"
-            },
-            "forecastGridData": {
-                "@type": "@id"
-            },
-            "publicZone": {
-                "@type": "@id"
-            },
-            "county": {
-                "@type": "@id"
-            }
-        }
-    ],
-    "id": "https://api.weather.gov/stations/KBOS/observations/2022-08-25T23:54:00+00:00",
-    "type": "Feature",
-    "geometry": {
-        "type": "Point",
-        "coordinates": [
-            -71.030000000000001,
-            42.369999999999997
-        ]
-    },
-    "properties": {
-        "@id": "https://api.weather.gov/stations/KBOS/observations/2022-08-25T23:54:00+00:00",
-        "@type": "wx:ObservationStation",
-        "elevation": {
-            "unitCode": "wmoUnit:m",
-            "value": 9
-        },
-        "station": "https://api.weather.gov/stations/KBOS",
-        "timestamp": "2022-08-25T23:54:00+00:00",
-        "rawMessage": "KBOS 252354Z 17007KT 10SM FEW070 FEW200 26/19 A2998 RMK A02 SLP153 T02610194 10278 20250 55001",
-        "textDescription": "Mostly Clear",
-        "icon": "https://api.weather.gov/icons/land/night/few?size=medium",
-        "presentWeather": [],
-        "temperature": {
-            "unitCode": "wmoUnit:degC",
-            "value": null,
-            "qualityControl": "Z"
-        },
-        "dewpoint": {
-            "unitCode": "wmoUnit:degC",
-            "value": null,
-            "qualityControl": "Z"
-        },
-        "windDirection": {
-            "unitCode": "wmoUnit:degree_(angle)",
-            "value": null,
-            "qualityControl": "Z"
-        },
-        "windSpeed": {
-            "unitCode": "wmoUnit:km_h-1",
-            "value": null,
-            "qualityControl": "Z"
-        },
-        "windGust": {
-            "unitCode": "wmoUnit:km_h-1",
-            "value": null,
-            "qualityControl": "Z"
-        },
-        "barometricPressure": {
-            "unitCode": "wmoUnit:Pa",
-            "value": null,
-            "qualityControl": "Z"
-        },
-        "seaLevelPressure": {
-            "unitCode": "wmoUnit:Pa",
-            "value": null,
-            "qualityControl": "Z"
-        },
-        "visibility": {
-            "unitCode": "wmoUnit:m",
-            "value": 16090,
-            "qualityControl": "C"
-        },
-        "maxTemperatureLast24Hours": {
-            "unitCode": "wmoUnit:degC",
-            "value": null
-        },
-        "minTemperatureLast24Hours": {
-            "unitCode": "wmoUnit:degC",
-            "value": null
-        },
-        "precipitationLastHour": {
-            "unitCode": "wmoUnit:m",
-            "value": null,
-            "qualityControl": "Z"
-        },
-        "precipitationLast3Hours": {
-            "unitCode": "wmoUnit:m",
-            "value": null,
-            "qualityControl": "Z"
-        },
-        "precipitationLast6Hours": {
-            "unitCode": "wmoUnit:m",
-            "value": null,
-            "qualityControl": "Z"
-        },
-        "relativeHumidity": {
-            "unitCode": "wmoUnit:percent",
-            "value": null,
-            "qualityControl": "Z"
-        },
-        "windChill": {
-            "unitCode": "wmoUnit:degC",
-            "value": null,
-            "qualityControl": "Z"
-        },
-        "heatIndex": {
-            "unitCode": "wmoUnit:degC",
-            "value": null,
-            "qualityControl": "Z"
-        },
-        "cloudLayers": [
-            {
-                "base": {
-                    "unitCode": "wmoUnit:m",
-                    "value": 2130
-                },
-                "amount": "FEW"
-            },
-            {
-                "base": {
-                    "unitCode": "wmoUnit:m",
-                    "value": 6100
-                },
-                "amount": "FEW"
-            }
-        ]
-    }
-}
-`
+const writePercent = 0.1
 
-func readAndWrite(keys []string, mc *memcache.Client, logger log.Logger) {
-	for {
-		start := rand.Intn(len(keys))
-		var end int
-		if len(keys)-start > numWrites {
-			end = start + numWrites
-		} else {
-			end = len(keys)
-		}
-
-		subset := keys[start:end]
-		for _, k := range subset {
-			err := mc.Set(&memcache.Item{
-				Key:        k,
-				Value:      []byte(payload),
-				Expiration: 300,
-			})
-
+func getPayloads(path string) map[string][]byte {
+	out := make(map[string][]byte)
+	err := filepath.WalkDir(path, func(path string, info fs.DirEntry, err error) error {
+		ext := filepath.Ext(path)
+		if ext == ".c" || ext == ".h" {
+			contents, err := os.ReadFile(path)
 			if err != nil {
-				level.Error(logger).Log("msg", "failed to set key", "key", k, "err", err)
+				return err
+			}
+
+			out[filepath.Base(path)] = contents
+		}
+		return nil
+	})
+
+	if err != nil {
+		panic(fmt.Sprintf("%s", err))
+	}
+
+	return out
+}
+
+func readAndWrite(payloads map[string][]byte, mc *memcache.Client, logger log.Logger) {
+	for {
+		keys := make([]string, 0, len(payloads))
+		for k, v := range payloads {
+			keys = append(keys, k)
+
+			if rand.Float64() < writePercent {
+				err := mc.Set(&memcache.Item{
+					Key:        k,
+					Value:      v,
+					Expiration: 300,
+				})
+
+				if err != nil {
+					level.Error(logger).Log("msg", "failed to set key", "key", k, "err", err)
+				}
 			}
 		}
-
-		//time.Sleep(time.Millisecond * time.Duration(rand.Int63n(1000)))
 
 		// SET a subset of keys but try to GET all of them - workloads will skew read heavy
 		_, err := mc.GetMulti(keys)
@@ -215,25 +68,21 @@ func readAndWrite(keys []string, mc *memcache.Client, logger log.Logger) {
 
 func main() {
 	logger := log.With(log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)), "ts", log.DefaultTimestampUTC)
-	//mc := memcache.New("localhost:11211", "localhost:11212", "localhost:11213")
 	mc := memcache.New("localhost:11211")
 	mc.MaxIdleConns = numBatches * 2
-	mc.Timeout = 400 * time.Millisecond
+	mc.Timeout = 2000 * time.Millisecond
 
+	// Get a map of all .c and .h filenames to their contents to use for keys and values
+	// to test the cache. Memcached is expected to be checked out in a parallel directory
+	// to jankcache.
+	payloads := getPayloads("../memcached")
 	wg := sync.WaitGroup{}
 
 	for batch := 0; batch < numBatches; batch++ {
-		start := batch * batchSize
-		var keys []string
-
-		for i := 0; i < batchSize; i++ {
-			keys = append(keys, fmt.Sprintf("somekey%d", i+start))
-		}
-
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			readAndWrite(keys, mc, logger)
+			readAndWrite(payloads, mc, logger)
 		}()
 	}
 


### PR DESCRIPTION
Account for trailing \r\n when reading the payload for `set` commands